### PR TITLE
Set system to x86_64-linux on non-linux platforms

### DIFF
--- a/nix/container.nix
+++ b/nix/container.nix
@@ -33,6 +33,7 @@ in
 
     boot.isContainer = true;
 
+    nixpkgs.system = mkIf (! any (platform: platform == builtins.currentSystem) platforms.linux) (mkOverride 900 "x86_64-linux");
   };
 
 }


### PR DESCRIPTION
Taken from https://github.com/NixOS/nixops/pull/412 to generate a minimal change
as an improvement of the current situation regarding remote building.

Adjusted to use "mkOverride 900" to make it consistent with all other backends.

If building a container on a non-linux system and "nixpkgs.system" is not set,
then we default now to "x86_64-linux".